### PR TITLE
case-insensitive image formats

### DIFF
--- a/jellyfin/client.py
+++ b/jellyfin/client.py
@@ -367,7 +367,7 @@ class JellyfinClient:
             raise Exception(f"Failed to download image from Spotify: {response.content}")
         
         # Step 2: Check the image content type (assume it's JPEG or PNG based on the content type from the response)
-        content_type = response.headers.get('Content-Type')
+        content_type = response.headers.get('Content-Type').lower()
         if content_type not in ['image/jpeg', 'image/png', 'application/octet-stream']:
             raise Exception(f"Unsupported image format: {content_type}")
         # Todo: 

--- a/jellyfin/client.py
+++ b/jellyfin/client.py
@@ -368,7 +368,7 @@ class JellyfinClient:
         
         # Step 2: Check the image content type (assume it's JPEG or PNG based on the content type from the response)
         content_type = response.headers.get('Content-Type').lower()
-        if content_type not in ['image/jpeg', 'image/png', 'application/octet-stream']:
+        if content_type not in ['image/jpeg', 'image/png', 'image/webp', 'application/octet-stream']:
             raise Exception(f"Unsupported image format: {content_type}")
         # Todo: 
         if content_type == 'application/octet-stream':


### PR DESCRIPTION
Sometimes the image format comes as `image/JPEG`, which results in an `Unsupported image format: image/JPEG`

Also fixes https://github.com/kamilkosek/jellyplist/issues/17#issuecomment-2518999639