### PR TITLE
make docker image slimmer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,12 @@ __pycache__/
 .DS_Store
 
 # Ignore Git files
-.git
+.git*
 *cookies*
 set_env.sh
 jellyplist.code-workspace
+
+# Ignore GitHub page related files
+changelogs
+readme.md
+screenshots


### PR DESCRIPTION
update docker-ignore to avoid adding to it unneeded files like readme and screenshots, as well as .github and .gitignore which are not needed inside the image