### PR TITLE
add CACHE_REDIS_HOST as env variable to config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ class Config:
     DISPLAY_EXTENDED_AUDIO_DATA = os.getenv('DISPLAY_EXTENDED_AUDIO_DATA',"false").lower() == 'true' 
     CACHE_TYPE = 'redis'
     CACHE_REDIS_PORT = 6379
-    CACHE_REDIS_HOST = 'redis'
+    CACHE_REDIS_HOST = os.getenv('CACHE_REDIS_HOST','redis')
     CACHE_REDIS_DB = 0
     CACHE_DEFAULT_TIMEOUT = 3600
     REDIS_URL = os.getenv('REDIS_URL','redis://redis:6379/0')


### PR DESCRIPTION
This is usefull for hosts not being "redis", in my env i have instance "jellyplist-redis" so i get this error, that can be fixed with this approach:


    connection.connect()
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 363, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error -2 connecting to redis:6379. Name or service not known.
[2025-01-26 14:30:00,011][          trace.py: 267 -                                 _log_error() ]   ERROR - Task app.tasks.update_all_playlists_track_status[4c9fc9f3-a5aa-48ef-a6bc-bfd38e4bb7c4] raised unexpected: ConnectionError('Error -2 connecting to redis:6379. Name or service not known.')
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 357, in connect
    sock = self.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/retry.py", line 62, in call_with_retry
    return do()
           ^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 358, in <lambda>
    lambda: self._connect(), lambda error: self.disconnect(error)
            ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 698, in _connect
    for res in socket.getaddrinfo(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/socket.py", line 976, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/jellyplist/app/tasks.py", line 33, in update_all_playlists_track_status
    if task_manager.acquire_lock(lock_key, expiration=600):
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/jellyplist/app/tasks.py", line 696, in acquire_lock
    return redis_client.set(lock_name, "locked", ex=expiration, nx=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/commands/core.py", line 2335, in set
    return self.execute_command("SET", *pieces, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/client.py", line 559, in execute_command
    return self._execute_command(*args, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/client.py", line 565, in _execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 1422, in get_connection
    connection.connect()
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 363, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error -2 connecting to redis:6379. Name or service not known.
[2025-01-26 14:35:00,008][          trace.py: 267 -                                 _log_error() ]   ERROR - Task app.tasks.update_all_playlists_track_status[4b0a6552-7a18-46a2-bc19-b87d4557dab4] raised unexpected: ConnectionError('Error -2 connecting to redis:6379. Name or service not known.')
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 357, in connect
    sock = self.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/retry.py", line 62, in call_with_retry
    return do()
           ^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 358, in <lambda>
    lambda: self._connect(), lambda error: self.disconnect(error)
            ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/redis/connection.py", line 698, in _connect
    for res in socket.getaddrinfo(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/socket.py", line 976, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known
