### PR TITLE
Resolved deprecated session data for Spotify Authentication

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -203,6 +203,7 @@ else:
     spotify_client = SpotifyClient()
     
 spotify_client.authenticate()
+app.logger.info('spotify auth successful')
 from .registry import MusicProviderRegistry
 MusicProviderRegistry.register_provider(spotify_client)
 

--- a/app/providers/spotify.py
+++ b/app/providers/spotify.py
@@ -191,6 +191,7 @@ class SpotifyClient(MusicProviderClient):
         # if the response is unauthorized, we need to reauthenticate
         if response.status_code == 401:
             l.debug("reauthenticating")
+            self.authenticate()
             headers['authorization'] = f'Bearer {self.access_token}'
             headers['client-token'] = self.client_token.get('token','')
             response = requests.get(f"{self.base_url}/{endpoint}", headers=headers, params=params, cookies=self.cookies)


### PR DESCRIPTION
Hi @kamilkosek, 

This PR has goal to resolve this Spotify authentication issue https://github.com/kamilkosek/jellyplist/issues/80  by fixing the failed fetch of the session and config data preventing users from successfully authenticating with Spotify. 

Please take a look. 

Here's a brief description of work done:

**_Updated script to be parsed for session_data from config to appServerConfig script_**
* config script is no longer returned from Fetch session data call from Spotify
* it's now called appServerConfig which contains the correlationId needed to make Spotify requests

 **_Updated functionality to fetch access_token and client_id required for making requests_**
* Removed deprecated session_data and its logic
* Added TOTP for new _get_access_token_and_client_id method
* Added some loggers

Thanks!